### PR TITLE
Read PORT from environment variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const app = express();
+require('dotenv').config();
+
 const port = process.env.PORT || 3001;
 
 app.get("/", (req, res) => res.type('html').send(html));

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node app.js"
   },
   "dependencies": {
+    "dotenv": "^16.0.3",
     "express": "^4.16.3"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
The port is hardcoded to 3001 or read from an environment variable. To be able to read the env variable this commit installs dotenv.

https://www.npmjs.com/package/dotenv

Without this change the deploy would fail, because the port 443 wasn't permitted

```
Error: listen EACCES: permission denied 0.0.0.0:443
```