### PR TITLE
Update keepAlive settings for server to avoid TCP race condition.

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,10 @@ const port = process.env.PORT || 3001;
 
 app.get("/", (req, res) => res.type('html').send(html));
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+const server = app.listen(port, () => console.log(`Example app listening on port ${port}!`));
 
+server.keepAliveTimeout = 120 * 1000;
+server.headersTimeout = 120 * 1000;
 
 const html = `
 <!DOCTYPE html>


### PR DESCRIPTION
In order to avoid race conditions with the render reverse proxy, we should set the keepAlive to be longer than 60s. Setting it to 2 minutes here just in case. 